### PR TITLE
Wide character I/O paths in Windows

### DIFF
--- a/luni/src/main/native/java_lang_System.cpp
+++ b/luni/src/main/native/java_lang_System.cpp
@@ -90,6 +90,12 @@ static jobjectArray System_specialProperties(JNIEnv* env, jclass) {
     properties.push_back("android.zlib.version=" ZLIB_VERSION);
     properties.push_back("android.openssl.version=" OPENSSL_VERSION_TEXT);
 
+#if defined(__MINGW32__) || defined(__MINGW64__)
+    // set some Windows-specific values to override those set by System.java/lang/System
+    properties.push_back("file.separator=\\");
+    properties.push_back("line.separator=\r\n");
+    properties.push_back("path.separator=;");
+#endif
     return toStringArray(env, properties);
 }
 

--- a/luni/src/main/native/libcore_io_Posix.cpp
+++ b/luni/src/main/native/libcore_io_Posix.cpp
@@ -159,6 +159,7 @@ struct addrinfo_deleter {
     #define u_open open
     #define u_lstat lstat
     #define u_stat stat
+    #define _stat stat
     #define u_access access
     #define u_chmod chmod
     #define u_chown chown
@@ -323,7 +324,7 @@ static jobject makeStructPasswd(JNIEnv* env, const struct passwd& pw) {
             pw_name, static_cast<jint>(pw.pw_uid), static_cast<jint>(pw.pw_gid), pw_dir, pw_shell);
 }
 
-static jobject makeStructStat(JNIEnv* env, const struct stat& sb) {
+static jobject makeStructStat(JNIEnv* env, const struct _stat& sb) {
 #if !defined(__MINGW32__) && !defined(__MINGW64__)
 	jlong blksize = static_cast<jlong>(sb.st_blksize);
 	jlong blocks = static_cast<jlong>(sb.st_blocks);
@@ -432,7 +433,7 @@ static jobject doStat(JNIEnv* env, jstring javaPath, bool isLstat) {
     if (path.c_str() == NULL) {
         return NULL;
     }
-    struct stat sb;
+    struct _stat sb;
     int rc = isLstat ? TEMP_FAILURE_RETRY(u_lstat(path.c_str(), &sb))
                      : TEMP_FAILURE_RETRY(u_stat(path.c_str(), &sb));
     if (rc == -1) {

--- a/luni/src/main/native/libcore_io_Posix.cpp
+++ b/luni/src/main/native/libcore_io_Posix.cpp
@@ -830,7 +830,7 @@ static jstring Posix_getenv(JNIEnv* env, jobject, jstring javaName) {
     }
 
     #if defined(__MINGW32__) || defined(__MINGW64__)
-    char* utf8value = utf16_to_utf8(u_getenv(name.c_str()), NULL);
+    char* utf8value = widechar_to_utf8(u_getenv(name.c_str()), NULL);
     jstring result = env->NewStringUTF(utf8value);
     delete[] utf8value;
     return result;

--- a/luni/src/main/native/libcore_io_Posix.cpp
+++ b/luni/src/main/native/libcore_io_Posix.cpp
@@ -167,6 +167,7 @@ struct addrinfo_deleter {
     #define u_chmod chmod
     #define u_chown chown
     #define u_execv execv
+    #define u_execve execve
     #define u_getenv getenv
     #define u_lchown lchown
     #define u_mkdir mkdir

--- a/luni/src/main/native/libcore_io_Posix.cpp
+++ b/luni/src/main/native/libcore_io_Posix.cpp
@@ -828,8 +828,15 @@ static jstring Posix_getenv(JNIEnv* env, jobject, jstring javaName) {
     if (name.c_str() == NULL) {
         return NULL;
     }
-    // TODO: convert wide string from _wgetenv to UTF8
+
+    #if defined(__MINGW32__) || defined(__MINGW64__)
+    char* utf8value = utf16_to_utf8(u_getenv(name.c_str()), NULL);
+    jstring result = env->NewStringUTF(utf8value);
+    delete[] utf8value;
+    return result;
+    #else
     return env->NewStringUTF(u_getenv(name.c_str()));
+    #endif
 }
 
 static jstring Posix_getnameinfo(JNIEnv* env, jobject, jobject javaAddress, jint flags) {

--- a/luni/src/main/native/mingw-extensions.cpp
+++ b/luni/src/main/native/mingw-extensions.cpp
@@ -119,13 +119,13 @@ int getpwuid_r(uid_t /*uid*/, struct passwd *pwd,
 #pragma GCC diagnostic pop
 
 // chown
-int chown(const char *path, uid_t owner, gid_t group)
+int _wchown(const wchar_t *path, uid_t owner, gid_t group)
 {
 	errno = EBADF;
 	FIXME_STUB_ERRNO("this function isn't supported yet");
 	return -1;
 }
-int lchown(const char *path, uid_t owner, gid_t group)
+int _wlchown(const wchar_t *path, uid_t owner, gid_t group)
 {
 	errno = EBADF;
 	FIXME_STUB_ERRNO("this function isn't supported yet");
@@ -148,10 +148,10 @@ int mincore(void *addr, size_t length, unsigned char *vec)
 }
 
 // mkdir
-int mkdir(const char *pathname, mode_t mode)
+int _wmkdir(const wchar_t *pathname, mode_t mode)
 {
 	// Just ignoring the mode
-	return mkdir(pathname);
+	return _wmkdir(pathname);
 }
 
 DWORD mmap_page(const int prot)
@@ -838,7 +838,7 @@ int asprintf(char **strp, const char *fmt, ...)
 
 // lstat
 
-int lstat(const char *path, struct stat *buf)
+int _wlstat(const wchar_t *path, struct _stat *buf)
 {
 	// We don't support symbolic links in Windows
 	errno = EBADF;
@@ -1217,7 +1217,7 @@ char *strsignal(int sig)
 
 // symlink
 
-int symlink(const char *path1, const char *path2)
+int _wsymlink(const wchar_t *path1, const wchar_t *path2)
 {
 	errno = EACCES;
 	FIXME_STUB("this function isn't implemented");

--- a/luni/src/main/native/mingw-extensions.cpp
+++ b/luni/src/main/native/mingw-extensions.cpp
@@ -1277,6 +1277,18 @@ SOCKET mingw_socket(int af, int type, int protocol) {
 	return result;
 }
 
+int mingw_connect(SOCKET s, const struct sockaddr *name, int namelen)
+{
+    int rc = connect(s, name, namelen);
+    if (rc == SOCKET_ERROR || rc == INVALID_SOCKET) {
+        int lastError = WSAGetLastError();
+        if (lastError == WSAEWOULDBLOCK) {
+            WSASetLastError(WSAEINPROGRESS);
+        }
+    }
+    return rc;
+}
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/luni/src/main/native/mingw-extensions.cpp
+++ b/luni/src/main/native/mingw-extensions.cpp
@@ -705,6 +705,19 @@ const char *inet_ntop(int af, const void *src, char *dst, size_t cnt) {
 	return dst;
 }
 
+// TODO: fill errno?..
+int _wunsetenv(const wchar_t *pname) {
+    return SetEnvironmentVariableW(pname, NULL);
+}
+
+int _wsetenv(const wchar_t *name, const wchar_t *value, int replace) {
+    if (replace == 0 && _wgetenv(name)) {
+        // variable already exists, and we were requested to not replace existing value
+        return 0;
+    }
+    return SetEnvironmentVariableW(name, value);
+}
+
 int fstatfs (int fd, struct statfs *buf)
 {
 	errno = EINVAL;
@@ -712,13 +725,15 @@ int fstatfs (int fd, struct statfs *buf)
 	return -1;
 }
 
-wchar_t *mingw_realpath(const wchar_t *path, wchar_t *resolved_path)
-{
+wchar_t *mingw_realpath(const wchar_t *path, wchar_t *resolved_path) {
     return GetFullPathNameW(path, MAX_PATH, resolved_path, NULL) ? resolved_path : NULL;
 }
 
-int _wstatfs(const wchar_t *path, struct statfs *buf)
-{
+char *mingw_realpath(const char *path, char *resolved_path) {
+    return GetFullPathNameA(path, MAX_PATH, resolved_path, NULL) ? resolved_path : NULL;
+}
+
+int _wstatfs(const wchar_t *path, struct statfs *buf) {
 	HINSTANCE h;
 	FARPROC f;
 	int retval = 0;

--- a/luni/src/main/native/mingw-extensions.cpp
+++ b/luni/src/main/native/mingw-extensions.cpp
@@ -24,8 +24,10 @@
 
 #include <stdarg.h>
 #include <ws2tcpip.h>
+#include <wchar.h>
 
 #include "mingw-extensions.h"
+#include "ScopedLocalRef.h"
 
 // If __PROVIDE_FIXMES is defined, every unimplemented function prints a FIXME message
 // Some functions are not implemented due to their uselessness in Java API, but they
@@ -776,12 +778,12 @@ int _wstatfs(const wchar_t *path, struct statfs *buf)
 	}
 
 	/* get the FS volume information */
-	if (strspn(":", resolved_path) > 0)
+	if (wcsspn(L":", resolved_path) > 0)
 		resolved_path[3] = '\0'; /* we want only the root */
 	if (GetVolumeInformationW(resolved_path, NULL, 0, (LPDWORD) &buf->f_fsid,
 			(LPDWORD) &buf->f_namelen, NULL, tmp, MAX_PATH))
 	{
-		if (strcasecmp("NTFS", tmp) == 0)
+		if (_wcsicmp(L"NTFS", tmp) == 0)
 		{
 			buf->f_type = NTFS_SUPER_MAGIC;
 		}
@@ -1887,7 +1889,7 @@ char* utf16_to_utf8(const wchar_t* utf16, int* length) {
     }
 
     // Get length of resulting UTF-8 string
-    int length_ = WideCharToMultiByte(CP_UTF8, MB_ERR_INVALID_CHARS, utf8, -1, NULL, 0, NULL, NULL);
+    int length_ = WideCharToMultiByte(CP_UTF8, MB_ERR_INVALID_CHARS, utf16, -1, NULL, 0, NULL, NULL);
     if (length_ == 0) {
         // some error happened... for now pretend input string was NULL
         return NULL;
@@ -1896,7 +1898,7 @@ char* utf16_to_utf8(const wchar_t* utf16, int* length) {
     // Allocate destination buffer for UTF-16 string
     char *result = new char[length_];
     // Do the conversion from UTF-8 to UTF-16
-    if (!WideCharToMultiByte(CP_UTF8, MB_ERR_INVALID_CHARS, utf8, -1, result, length_, NULL, NULL)) {
+    if (!WideCharToMultiByte(CP_UTF8, MB_ERR_INVALID_CHARS, utf16, -1, result, length_, NULL, NULL)) {
         // some error happened... for now pretend input string was NULL
         delete[] result;
         return NULL;

--- a/luni/src/main/native/mingw-extensions.h
+++ b/luni/src/main/native/mingw-extensions.h
@@ -511,14 +511,8 @@ int inet_pton(int af, const char *src, void *dst);
 const char *inet_ntop(int af, const void *src, char *dst, size_t cnt);
 // stdlib.h
 
-#define _wunsetenv(pname) SetEnvironmentVariableW(pname, NULL)
-int _wsetenv(const wchar_t *name, const wchar_t *value, int replace) {
-    if (replace == 0 && _wgetenv(name)) {
-        // variable already exists, and we were requested to not replace existing value
-        return 0;
-    }
-    return SetEnvironmentVariableW(name, value);
-}
+int _wunsetenv(const wchar_t *pname);
+int _wsetenv(const wchar_t *name, const wchar_t *value, int replace);
 
 // termios.h
 
@@ -562,6 +556,7 @@ int mingw_connect(SOCKET s, const struct sockaddr *name, int namelen);
 
 // An equivalent for POSIX realpath function
 char *mingw_realpath(const char *path, char *resolved_path);
+wchar_t *mingw_realpath(const wchar_t *path, wchar_t *resolved_path);
 
 // Converts Windows API error code into errno code
 int windowsErrorToErrno(DWORD winErr);

--- a/luni/src/main/native/mingw-extensions.h
+++ b/luni/src/main/native/mingw-extensions.h
@@ -555,6 +555,11 @@ int mingw_close(int fd);
  * for newer OSes set IPV6_V6ONLY to "false" for AF_INET6 sockets */
 SOCKET mingw_socket(int af, int type, int protocol);
 
+/* On Windows connect() functions set errno to EWOULDBLOCK, but Posix API expects EINPROGRESS
+ * in this case, so we wrap the function. 
+*/
+int mingw_connect(SOCKET s, const struct sockaddr *name, int namelen);
+
 // An equivalent for POSIX realpath function
 char *mingw_realpath(const char *path, char *resolved_path);
 

--- a/luni/src/main/native/mingw-extensions.h
+++ b/luni/src/main/native/mingw-extensions.h
@@ -593,17 +593,17 @@ class ScopedWideChars {
             return data_;
         }
 
-        const size_t size() const {
+        const int size() const {
             return length_;
         }
 
-        const wchar_t& operator[](size_t n) const {
+        const wchar_t& operator[](int n) const {
             return data_[n];
         }
 
     private:
         wchar_t* data_;
-        size_t length_;
+        int length_;
         
         void fillUtf16Data(const char* utf8);
 

--- a/luni/src/main/native/mingw-extensions.h
+++ b/luni/src/main/native/mingw-extensions.h
@@ -36,6 +36,7 @@
 #include <iphlpapi.h>
 
 #include "Portability.h"
+#include "jni.h"
 
 // errno.h
 
@@ -572,5 +573,42 @@ const char* getErrnoDescription(int err);
 #ifdef MINGW_HAS_SECURE_API
 	extern "C" int strerror_r(int errno, char *buf, size_t len) ;
 #endif
+
+// A smart pointer that provides read-only access to a wide-char strings.
+// Its behaviour is identical to ScopedUtfChars (see ScopedUtfChars.h)
+class ScopedWideChars {
+    public:
+        ScopedWideChars(JNIEnv* env, jstring s);
+
+        ~ScopedWideChars() {
+            if (data_ != NULL) {
+                free(data_);
+            }
+        }
+        
+        
+        const wchar_t* c_str() const {
+            return data_;
+        }
+
+        const size_t size() const {
+            return length_;
+        }
+
+        const wchar_t& operator[](size_t n) const {
+            return data_[n];
+        }
+
+    private:
+        wchar_t* data_;
+        size_t length_;
+        
+        void fillUtf16Data(const char* utf8);
+
+        // Disallow copy and assignment.
+        ScopedWideChars(const ScopedWideChars&) {};
+        void operator=(const ScopedWideChars&) {};
+};
+
 
 #endif

--- a/luni/src/main/native/mingw-extensions.h
+++ b/luni/src/main/native/mingw-extensions.h
@@ -438,7 +438,7 @@ struct statfs {
 };
 
 int fstatfs(int fd, struct statfs *buf);
-int statfs(const char *path, struct statfs *buf);
+int _wstatfs(const wchar_t *path, struct statfs *buf);
 
 // poll.h
 
@@ -511,15 +511,14 @@ int inet_pton(int af, const char *src, void *dst);
 const char *inet_ntop(int af, const void *src, char *dst, size_t cnt);
 // stdlib.h
 
-#define unsetenv(pname) SetEnvironmentVariable(pname, NULL)
-#define setenv(__pname,__pvalue,___overwrite) \
-({ \
-  int result; \
- if (___overwrite == 0 && getenv (__pname)) result = 0; \
-   else \
-     result = SetEnvironmentVariable (__pname,__pvalue); \
- result; \
-})
+#define _wunsetenv(pname) SetEnvironmentVariableW(pname, NULL)
+int _wsetenv(const wchar_t *name, const wchar_t *value, int replace) {
+    if (replace == 0 && _wgetenv(name)) {
+        // variable already exists, and we were requested to not replace existing value
+        return 0;
+    }
+    return SetEnvironmentVariableW(name, value);
+}
 
 // termios.h
 
@@ -574,7 +573,8 @@ const char* getErrnoDescription(int err);
 	extern "C" int strerror_r(int errno, char *buf, size_t len) ;
 #endif
 
-const wchar_t* utf8_to_utf16(const char* utf8);
+wchar_t* utf8_to_utf16(const char* utf8, int* length);
+char* utf16_to_utf8(const wchar_t* utf16, int* length);
 
 // A smart pointer that provides read-only access to a wide-char strings.
 // Its behaviour is identical to ScopedUtfChars (see ScopedUtfChars.h)

--- a/luni/src/main/native/mingw-extensions.h
+++ b/luni/src/main/native/mingw-extensions.h
@@ -574,6 +574,8 @@ const char* getErrnoDescription(int err);
 	extern "C" int strerror_r(int errno, char *buf, size_t len) ;
 #endif
 
+const wchar_t* utf8_to_utf16(const char* utf8);
+
 // A smart pointer that provides read-only access to a wide-char strings.
 // Its behaviour is identical to ScopedUtfChars (see ScopedUtfChars.h)
 class ScopedWideChars {
@@ -582,7 +584,7 @@ class ScopedWideChars {
 
         ~ScopedWideChars() {
             if (data_ != NULL) {
-                free(data_);
+                delete[] data_;
             }
         }
         
@@ -606,9 +608,27 @@ class ScopedWideChars {
         void fillUtf16Data(const char* utf8);
 
         // Disallow copy and assignment.
-        ScopedWideChars(const ScopedWideChars&) {};
-        void operator=(const ScopedWideChars&) {};
+        ScopedWideChars(const ScopedWideChars&);
+        void operator=(const ScopedWideChars&);
 };
 
+// wchar_t version of ExecStrings, for more see Android's ExecStrings.h
+class ExecWideStrings {
+    public:
+        ExecWideStrings(JNIEnv* env, jobjectArray java_string_array);
+        ~ExecWideStrings();
+        wchar_t** get() {
+            return array_;
+        }
+
+    private:
+        JNIEnv* env_;
+        jobjectArray java_array_;
+        wchar_t** array_;
+
+        // Disallow copy and assignment.
+        ExecWideStrings(const ExecWideStrings&);
+        void operator=(const ExecWideStrings&);
+};
 
 #endif

--- a/luni/src/main/native/mingw-extensions.h
+++ b/luni/src/main/native/mingw-extensions.h
@@ -376,10 +376,10 @@ int setegid(gid_t egid);
 int setgid(gid_t gid);
 pid_t setsid();
 int setuid(uid_t euid);
-int chown(const char *path, uid_t owner, gid_t group);
-int lchown(const char *path, uid_t owner, gid_t group);
+int _wchown(const wchar_t *path, uid_t owner, gid_t group);
+int _wlchown(const wchar_t *path, uid_t owner, gid_t group);
 int fchown(int fd, uid_t owner, gid_t group);
-int symlink(const char *path1, const char *path2);
+int _wsymlink(const wchar_t *path1, const wchar_t *path2);
 int sysconf(int name);
 ssize_t pread64(int fd, void *buf, size_t count, off_t offset);
 ssize_t pwrite64(int fd, const void *buf, size_t count, off_t offset);
@@ -417,8 +417,8 @@ int ioctl(int fd, int request, void *argp);
 #define S_IXOTH					00001
 
 int fchmod(int fd, mode_t mode);
-int lstat(const char *path, struct stat *buf);
-int mkdir(const char *pathname, mode_t mode);
+int _wlstat(const wchar_t *path, struct _stat *buf);
+int _wmkdir(const wchar_t *pathname, mode_t mode);
 
 // statfs.h
 

--- a/luni/src/main/native/mingw-extensions.h
+++ b/luni/src/main/native/mingw-extensions.h
@@ -568,40 +568,25 @@ const char* getErrnoDescription(int err);
 	extern "C" int strerror_r(int errno, char *buf, size_t len) ;
 #endif
 
-wchar_t* utf8_to_utf16(const char* utf8, int* length);
-char* utf16_to_utf8(const wchar_t* utf16, int* length);
+wchar_t* utf8_to_widechar(const char* utf8, int* length);
+char* widechar_to_utf8(const wchar_t* utf16, int* length);
 
 // A smart pointer that provides read-only access to a wide-char strings.
 // Its behaviour is identical to ScopedUtfChars (see ScopedUtfChars.h)
 class ScopedWideChars {
     public:
         ScopedWideChars(JNIEnv* env, jstring s);
+        ~ScopedWideChars();
 
-        ~ScopedWideChars() {
-            if (data_ != NULL) {
-                delete[] data_;
-            }
-        }
-        
-        
-        const wchar_t* c_str() const {
-            return data_;
-        }
-
-        const int size() const {
-            return length_;
-        }
-
-        const wchar_t& operator[](int n) const {
-            return data_[n];
-        }
+        const wchar_t* c_str() const;
+        const int size() const;
+        const wchar_t& operator[](int n) const;
 
     private:
-        wchar_t* data_;
-        int length_;
+        JNIEnv* env_;
+        jstring string_;
+        const wchar_t* data_;
         
-        void fillUtf16Data(const char* utf8);
-
         // Disallow copy and assignment.
         ScopedWideChars(const ScopedWideChars&);
         void operator=(const ScopedWideChars&);
@@ -612,9 +597,7 @@ class ExecWideStrings {
     public:
         ExecWideStrings(JNIEnv* env, jobjectArray java_string_array);
         ~ExecWideStrings();
-        wchar_t** get() {
-            return array_;
-        }
+        wchar_t** get();
 
     private:
         JNIEnv* env_;


### PR DESCRIPTION
Windows is a unique OS that doesn't like to "just use UTF-8 in file names and be nice" like every other platform. It uses UCS-2 for paths and has special API functions for working with them. Default <code>open</code>, <code>mkdir</code> and so on doesn't support anything outside ANSI.

So @JustAMan has made some additions to our "Windows-supporting-POSIX-layer" to make it working with wide-character filenames.

We made some basic testing (although it's incomplete, but a complete testing would take too much time).

Would you like to merge it?
