### PR TITLE
The new libcore is patched for Windows and OS X

### DIFF
--- a/luni/src/main/java/java/io/File.java
+++ b/luni/src/main/java/java/io/File.java
@@ -183,6 +183,13 @@ public class File implements Serializable, Comparable<File> {
 
     // Removes duplicate adjacent slashes and any trailing slash.
     private static String fixSlashes(String origPath) {
+    	/* On Windows both "/" and "\" are supported as file separators, but 
+    	 * file.separator is set to "\", which breaks handling of paths like "c:/something".
+    	 * So in case of Windows system we first canonicalize separators to "\" 
+    	 */
+    	if (Libcore.os instanceof WinOs) {
+    		origPath = origPath.replace('/', separatorChar);
+    	}
         // Remove duplicate adjacent slashes.
         boolean lastWasSlash = false;
         char[] newPath = origPath.toCharArray();

--- a/luni/src/main/native/canonicalize_path.cpp
+++ b/luni/src/main/native/canonicalize_path.cpp
@@ -34,7 +34,7 @@
 
 #include "mingw-extensions.h"
 
-bool realpath(const char* path, std::string& resolved_path) {
+bool canonicalize_path(const char* path, std::string& resolved_path) {
     char resolved[MAX_PATH];
     bool res = mingw_realpath(path, resolved);
 	resolved_path.assign(resolved);

--- a/luni/src/main/native/canonicalize_path.cpp
+++ b/luni/src/main/native/canonicalize_path.cpp
@@ -34,8 +34,8 @@
 
 #include "mingw-extensions.h"
 
-bool canonicalize_path(const char* path, std::string& resolved_path) {
-    char resolved[MAX_PATH];
+bool canonicalize_path(const wchar_t* path, std::wstring& resolved_path) {
+    wchar_t resolved[MAX_PATH];
     bool res = mingw_realpath(path, resolved);
 	resolved_path.assign(resolved);
 	return res;

--- a/luni/src/main/native/libcore_io_Posix.cpp
+++ b/luni/src/main/native/libcore_io_Posix.cpp
@@ -75,6 +75,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include "unicode-defines.h"
 
 #ifndef __unused
 #define __unused __attribute__((__unused__))
@@ -196,58 +197,6 @@ struct addrinfo_deleter {
     } \
     _rc; })
 #endif
-
-// This is about necessity to use wide-char functions on Windows to correctly support Unicode
-#if defined(__MINGW32__) || defined(__MINGW64__)
-    #define ScopedPathChars ScopedWideChars
-    #define ExecPathStrings ExecWideStrings
-    #define u_open _wopen
-    #define u_lstat _wlstat
-    #define u_stat _wstat
-    #define u_access _waccess
-    #define u_chmod _wchmod
-    #define u_chown _wchown
-    #define u_execve _wexecve
-    #define u_execv _wexecv
-    #define u_getenv _wgetenv
-    #define u_lchown _wlchown
-    #define u_mkdir _wmkdir
-    #define u_remove _wremove
-    #define u_rename _wrename
-    #define u_setenv _wsetenv
-    #define u_statfs _wstatfs
-    #define u_symlink _wsymlink
-    #define u_unsetenv _wunsetenv
-    #define u_link _wlink
-    #define u_mkfifo _wmkfifo
-    #define u_statvfs _wstatvfs
-#else
-    #define ScopedPathChars ScopedUtfChars
-    #define ExecPathStrings ExecStrings
-    #define u_open open
-    #define u_lstat lstat
-    #define u_stat stat
-    #define _stat stat
-    #define _fstat fstat
-    #define u_access access
-    #define u_chmod chmod
-    #define u_chown chown
-    #define u_execv execv
-    #define u_execve execve
-    #define u_getenv getenv
-    #define u_lchown lchown
-    #define u_mkdir mkdir
-    #define u_remove remove
-    #define u_rename rename
-    #define u_setenv setenv
-    #define u_statfs statfs
-    #define u_symlink symlink
-    #define u_unsetenv unsetenv
-    #define u_link link
-    #define u_mkfifo mkfifo
-    #define u_statvfs statvfs
-#endif
-
 
 static void throwException(JNIEnv* env, jclass exceptionClass, jmethodID ctor3, jmethodID ctor2,
         const char* functionName, int error) {
@@ -900,9 +849,7 @@ static jstring Posix_getenv(JNIEnv* env, jobject, jstring javaName) {
     }
 
     #if defined(__MINGW32__) || defined(__MINGW64__)
-    char* utf8value = widechar_to_utf8(u_getenv(name.c_str()), NULL);
-    jstring result = env->NewStringUTF(utf8value);
-    delete[] utf8value;
+    jstring result = env->NewString(u_getenv(name.c_str()), name.size());
     return result;
     #else
     return env->NewStringUTF(u_getenv(name.c_str()));

--- a/luni/src/main/native/mingw-extensions.cpp
+++ b/luni/src/main/native/mingw-extensions.cpp
@@ -370,6 +370,13 @@ exit:
 	return res;
 }
 
+int posix_fallocate64(int fd, off64_t offset, off64_t len) 
+{
+	errno = EBADF;
+	FIXME_STUB_ERRNO("this function isn't supported yet");
+	return -1;
+}
+
 // fdatasync
 
 int fdatasync(int fd)
@@ -472,6 +479,14 @@ int uname(struct utsname *buf)
 	strcpy(buf->nodename, "localhost");
 	
 	return 0;
+}
+
+int prctl(int option, unsigned long arg2, unsigned long arg3, unsigned long arg4, 
+          unsigned long arg5)
+{
+    errno = EBADF;
+    FIXME_STUB_ERRNO("this function isn't supported yet");
+    return -1;
 }
 
 int ioctl(int fd, int request, void *argp)
@@ -719,6 +734,20 @@ int _wsetenv(const wchar_t *name, const wchar_t *value, int replace) {
 }
 
 int fstatfs (int fd, struct statfs *buf)
+{
+	errno = EINVAL;
+	FIXME_STUB_ERRNO("this function isn't supported yet");
+	return -1;
+}
+
+int fstatvfs (int fd, struct statvfs *buf)
+{
+	errno = EINVAL;
+	FIXME_STUB_ERRNO("this function isn't supported yet");
+	return -1;
+}
+
+int _wstatvfs(const wchar_t *path, struct statvfs *buf)
 {
 	errno = EINVAL;
 	FIXME_STUB_ERRNO("this function isn't supported yet");
@@ -1193,6 +1222,20 @@ ssize_t pwrite64(int fd, const void *buf, size_t count, off_t offset)
     lseek (fd, saved_pos, SEEK_SET);
 
     return retval;
+}
+
+int _wlink(const wchar_t *path1, const wchar_t *path2)
+{
+	errno = EINVAL;
+	FIXME_STUB_ERRNO("this function isn't implemented");
+	return -1;
+}
+
+int _wmkfifo(const wchar_t *pathname, mode_t mode)
+{
+	errno = EINVAL;
+	FIXME_STUB_ERRNO("this function isn't implemented");
+	return -1;
 }
 
 ssize_t sendfile(int out_fd, int in_fd, off_t * offset, size_t count)

--- a/luni/src/main/native/mingw-extensions.h
+++ b/luni/src/main/native/mingw-extensions.h
@@ -392,6 +392,9 @@ int sysconf(int name);
 ssize_t pread64(int fd, void *buf, size_t count, off_t offset);
 ssize_t pwrite64(int fd, const void *buf, size_t count, off_t offset);
 
+int _wlink(const wchar_t *path1, const wchar_t *path2);
+int _wmkfifo(const wchar_t *pathname, mode_t mode);
+
 // sys/fcntl.h
 
 struct flock64 {
@@ -403,9 +406,15 @@ struct flock64 {
 };
 int fcntl(int fd, int cmd, ... /* arg */ );
 
+int posix_fallocate64(int fd, off64_t offset, off64_t len);
+
 // sys/ioctl.h
 
 int ioctl(int fd, int request, void *argp);
+
+// sys/prctl.h
+int prctl(int option, unsigned long arg2, unsigned long arg3, unsigned long arg4, 
+          unsigned long arg5);
 
 // sys/stat.h
 
@@ -490,6 +499,9 @@ struct statvfs64 {
 	char f_basetype[FSTYPSZ];
 	char f_str[FSSTRSZ];
 } statvfs64_t; 
+
+int fstatvfs(int fd, struct statvfs *buf);
+int _wstatvfs(const wchar_t *path, struct statvfs *buf);
 
 // poll.h
 

--- a/luni/src/main/native/mingw-extensions.h
+++ b/luni/src/main/native/mingw-extensions.h
@@ -483,23 +483,6 @@ struct statvfs {
 	char f_str[FSSTRSZ];
 }; 
 
-struct statvfs64 {
-	unsigned long f_bsize;
-	unsigned long f_frsize;
-	fsblkcnt64_t f_blocks;
-	fsblkcnt64_t f_bfree;
-	fsblkcnt64_t f_bavail;
-	fsfilcnt64_t f_files;
-	fsfilcnt64_t f_ffree;
-	fsfilcnt64_t f_favail;
-	unsigned long f_fsid;
-	unsigned long f_flag;
-	unsigned long f_namemax;
-	unsigned long f_type;
-	char f_basetype[FSTYPSZ];
-	char f_str[FSSTRSZ];
-} statvfs64_t; 
-
 int fstatvfs(int fd, struct statvfs *buf);
 int _wstatvfs(const wchar_t *path, struct statvfs *buf);
 

--- a/luni/src/main/native/mingw-extensions.h
+++ b/luni/src/main/native/mingw-extensions.h
@@ -309,6 +309,14 @@ enum sock_shutdown_cmd {
 
 #define IF_NAMESIZE				256
 
+enum rt_scope_t {
+    RT_SCOPE_UNIVERSE = 0,
+    RT_SCOPE_SITE = 200,
+    RT_SCOPE_LINK = 253,
+    RT_SCOPE_HOST = 254,
+    RT_SCOPE_NOWHERE = 255
+};
+
 typedef unsigned int uid_t;
 typedef unsigned int gid_t;
 typedef long loff_t;

--- a/luni/src/main/native/mingw-extensions.h
+++ b/luni/src/main/native/mingw-extensions.h
@@ -448,6 +448,49 @@ struct statfs {
 int fstatfs(int fd, struct statfs *buf);
 int _wstatfs(const wchar_t *path, struct statfs *buf);
 
+// sys/types.h
+typedef unsigned long	fsblkcnt_t;
+typedef unsigned long   fsfilcnt_t;
+typedef unsigned long long  fsblkcnt64_t;
+typedef unsigned long long  fsfilcnt64_t;
+#define FSTYPSZ 32
+#define FSSTRSZ 32
+
+// statvfs.h
+struct statvfs {
+	unsigned long f_bsize;
+	unsigned long f_frsize;
+	fsblkcnt_t f_blocks;
+	fsblkcnt_t f_bfree;
+	fsblkcnt_t f_bavail;
+	fsfilcnt_t f_files;
+	fsfilcnt_t f_ffree;
+	fsfilcnt_t f_favail;
+	unsigned long f_fsid;
+	unsigned long f_flag;
+	unsigned long f_namemax;
+	unsigned long f_type;
+	char f_basetype[FSTYPSZ];
+	char f_str[FSSTRSZ];
+}; 
+
+struct statvfs64 {
+	unsigned long f_bsize;
+	unsigned long f_frsize;
+	fsblkcnt64_t f_blocks;
+	fsblkcnt64_t f_bfree;
+	fsblkcnt64_t f_bavail;
+	fsfilcnt64_t f_files;
+	fsfilcnt64_t f_ffree;
+	fsfilcnt64_t f_favail;
+	unsigned long f_fsid;
+	unsigned long f_flag;
+	unsigned long f_namemax;
+	unsigned long f_type;
+	char f_basetype[FSTYPSZ];
+	char f_str[FSSTRSZ];
+} statvfs64_t; 
+
 // poll.h
 
 struct pollfd {

--- a/luni/src/main/native/unicode-defines.h
+++ b/luni/src/main/native/unicode-defines.h
@@ -56,7 +56,6 @@
     #define u_open open
     #define u_lstat lstat
     #define u_stat stat
-    #define _stat stat
     #define _fstat fstat
     #define u_access access
     #define u_chmod chmod
@@ -84,6 +83,8 @@
     #define u_string_t std::string
     #define u_DIR DIR
     #define u_dirent dirent
+    #define _stat stat
+    #define _utimbuf utimbuf
 #endif
 
 #endif // UNICODE_DEFINES_H

--- a/luni/src/main/native/unicode-defines.h
+++ b/luni/src/main/native/unicode-defines.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2014 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef UNICODE_DEFINES_H
+#define UNICODE_DEFINES_H
+
+// This is about necessity to use wide-char functions on Windows to correctly support Unicode
+#if defined(__MINGW32__) || defined(__MINGW64__)
+    #define ScopedPathChars ScopedWideChars
+    #define ExecPathStrings ExecWideStrings
+    #define u_open _wopen
+    #define u_lstat _wlstat
+    #define u_stat _wstat
+    #define u_access _waccess
+    #define u_chmod _wchmod
+    #define u_chown _wchown
+    #define u_execve _wexecve
+    #define u_execv _wexecv
+    #define u_getenv _wgetenv
+    #define u_lchown _wlchown
+    #define u_mkdir _wmkdir
+    #define u_remove _wremove
+    #define u_rename _wrename
+    #define u_setenv _wsetenv
+    #define u_statfs _wstatfs
+    #define u_symlink _wsymlink
+    #define u_unsetenv _wunsetenv
+    #define u_link _wlink
+    #define u_mkfifo _wmkfifo
+    #define u_statvfs _wstatvfs
+    #define u_utime _wutime
+    #define u_opendir _wopendir
+    #define u_closedir _wclosedir
+    #define u_readdir _wreaddir
+
+    #define u_char_t wchar_t
+    #define u_string_t std::wstring
+    #define u_DIR _WDIR
+    #define u_dirent _wdirent
+#else
+    #define ScopedPathChars ScopedUtfChars
+    #define ExecPathStrings ExecStrings
+    #define u_open open
+    #define u_lstat lstat
+    #define u_stat stat
+    #define _stat stat
+    #define _fstat fstat
+    #define u_access access
+    #define u_chmod chmod
+    #define u_chown chown
+    #define u_execv execv
+    #define u_execve execve
+    #define u_getenv getenv
+    #define u_lchown lchown
+    #define u_mkdir mkdir
+    #define u_remove remove
+    #define u_rename rename
+    #define u_setenv setenv
+    #define u_statfs statfs
+    #define u_symlink symlink
+    #define u_unsetenv unsetenv
+    #define u_link link
+    #define u_mkfifo mkfifo
+    #define u_statvfs statvfs
+    #define u_utime utime
+    #define u_opendir opendir
+    #define u_closedir closedir
+    #define u_readdir readdir
+
+    #define u_char_t char
+    #define u_string_t std::string
+    #define u_DIR DIR
+    #define u_dirent dirent
+#endif
+
+#endif // UNICODE_DEFINES_H


### PR DESCRIPTION
I'm happy to inform you that the patching is done :) Now the new Android class path version seems to work along with Avian on Windows 7, OS X and Linux. There could be bugs (just as always), but we did some basic testing and nothing critical is found.

But unfortunately this pull request contains only a part (the major part) of the changes. We had to make some changes in two other repositories. One of them is Avian itself (pull request https://github.com/ReadyTalk/avian/pull/343). And the other one is the new conscrypt repo. The changes are made in my fork as a part of avian-pack. The conscrypt repo itself is here: https://github.com/bigfatbrowncat/avian-pack.android.external.conscrypt

You may fork this repo as well as you forked libcore. If it's not a good idea, please, let us know.

By the way: the current version of avian-pack builds with all the correct versions of the repositories (you can see them in my GitHub account. Their names start with "avian-pack.")
